### PR TITLE
Check current system locale (dot vs. comma. as decimal separator)

### DIFF
--- a/R/createReport.R
+++ b/R/createReport.R
@@ -417,8 +417,7 @@ createReport = function(txt_folder = NULL, mztab_file = NULL, yaml_obj = list(),
     ## Even if MBR=off, this column always contains numbers (usually 0, or very small)
     ##
     
-    
-    if (!("retention.time.calibration" %in% colnames(df_evd)))
+    if ("retention.time.calibration" %in% colnames(df_evd))
     {
       ## this should enable us to decide if MBR was used (we could also look up parameters.txt -- if present)
       if (!(yaml_param$param_evd_mbr == FALSE) & nrow(df_evd_tf)>0)
@@ -445,7 +444,7 @@ createReport = function(txt_folder = NULL, mztab_file = NULL, yaml_obj = list(),
         lst_qcMetrics[["qcMetric_EVD_MBRaux"]]$setData(df_evd)
         
       } ## MBR has data
-    } ## retention.time.difference column exists
+    } ## retention.time.calibration column exists
     
     
     ##


### PR DESCRIPTION
fixes https://github.com/cbielow/PTXQC/issues/98

i.e.: warns if the current locale uses a comma as decimal separator (common for german systems and others).

Also checks if the txt-folder was generated on a system with the correct locale (already introduced here https://github.com/cbielow/PTXQC/commit/86fb156029b6759466ec3d5288c014d60c30d90e)

The new report how has a `Check` section at the very top, which informs about static and dynamic check results:
![image](https://user-images.githubusercontent.com/6008722/119979693-9684b080-bfbb-11eb-8bde-84b08d164124.png)
