### PR TITLE
fix request for mqpar.xml (for mzQC file) when processing mzTab

### DIFF
--- a/R/createReport.R
+++ b/R/createReport.R
@@ -167,7 +167,8 @@ createReport = function(txt_folder = NULL, mztab_file = NULL, yaml_obj = list(),
   
   ## get full filenames (and their suffix -- for mzQC metadata)
   file_meta = QCMetaFilenames$new()
-  file_meta$data = getMetaFilenames(txt_files$mqpar, base_folder)
+  ## does only work if mqpar.xml is present (for now)
+  if (!MZTAB_MODE) file_meta$data = getMetaFilenames(txt_files$mqpar, base_folder)
   ## --> wherever you need this data, simply re-grab the singleton using 'QCMetaFilenames$new()$data'
   
   ######

--- a/R/fcn_mqpar.R
+++ b/R/fcn_mqpar.R
@@ -25,7 +25,7 @@ getMQPARValue = function(mqpar_filename, xpath, allow_multiple = FALSE)
 {
   #xpath = "//firstSearchTol"
   #mqpar_filename = txt_files$mqpar
-  if (!file.exists(pattern=mqpar_filename)) {
+  if (!file.exists(mqpar_filename)) {
     message("Info: The file '", mqpar_filename, "' was not found. MaxQuant parameters could not be extracted. Will fall back to default value, which however is only an approximation.",
             " Please either: a) copy the mqpar.xml which was used for this MQ analysis into your TXT folder or,",
             " b) make sure that you configure all YAML parameters whose name starts with 'MQpar_' correctly.", immediate. = TRUE)


### PR DESCRIPTION
for mzTab input only:

prevents error `Error in file.exists(pattern = mqpar_filename) : invalid 'file' argument`

see https://github.com/nf-core/proteomicslfq/issues/174