### PR TITLE
use minmum from data for reporter ion plot

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: PTXQC
 Type: Package
 Title: Quality Report Generation for MaxQuant and mzTab Results
-Version: 1.0.14
+Version: 1.0.15
 Date: 2022-09-21
 Author: Chris Bielow [aut, cre],
   Juliane Schmachtenberg [ctb],

--- a/NEWS
+++ b/NEWS
@@ -3,9 +3,20 @@ i.e. a list of new features / bugfixes by version number.
 
 Versions uploaded to CRAN are marked with [CRAN].
 
+Glossary:
+ 'pr' means 'pull request' on GitHub
+ 'issue' is an issue on GitHub
+ 
+ The respective details can be found by visiting GitHub, e.g. https://github.com/cbielow/PTXQC/pull/124
+ for pr #124 (you can use the same URL also for issues)
+
 #################################
 #########   CHANGELOG  ##########
 #################################
+
+PRE!!! v1.00.15 -- 2022/??/??
+  - better reporter ion minimum range in violin plot (pr #124)
+
 
 [CRAN] v1.00.14 -- 2022/09/21
   - [FIX] crash when re-running PTX-QC on a txt folder where a (very old) PTX-QC was already run (issue #118)

--- a/R/qcMetric_EVD.R
+++ b/R/qcMetric_EVD.R
@@ -307,12 +307,11 @@ Each Raw file is now scored by the minimum LE of all its 4 channels.
       dt_reps$channel = factor(dt_reps$channel, levels = sort(unique(dt_reps$channel), decreasing = TRUE))
       head(dt_reps)
       
-      ylims_minmax = range(dt_reps$intensity)
+      ylims_minmax = range(dt_reps$intensity[dt_reps$intensity>0])
+      if (is.na(ylims_minmax[1])) {ylims_minmax = range(1)} ## data is all 0! Make range at least 1, so log-range does not crash
       
       fcn_boxplot_internal = function(data, title_subtext = title_subtext, title_color = title_color) 
       {
-        #require(ggplot2)
-        #data = ylims
         ### first subplot (distribution of intensities)
         data_noZero = data[data$intensity!=0,]
         pl = ggplot(data=data_noZero) +
@@ -330,9 +329,8 @@ Each Raw file is now scored by the minimum LE of all its 4 channels.
                 legend.position = "right",
                 plot.title = element_text(color = title_color)) +
           ggtitle(g_title, title_subtext) + 
-          #scale_alpha(range = range(ylims$labEff_PC)) +
           PTXQC:::scale_x_discrete_reverse(unique(data$fc.raw.file)) +
-          scale_y_log10(limits = ylims_minmax + 1) + ## +1 to make sure that lower bound is not 0 (--> since log(0) = error)
+          scale_y_log10(limits = ylims_minmax) +
           coord_flip() 
         #pl
         


### PR DESCRIPTION
use the actual minimum non-zero reporter ion intensity for iTRAQ/TMT violin plots