### PR TITLE
Use named `guide` argument

### DIFF
--- a/R/fcn_plots.R
+++ b/R/fcn_plots.R
@@ -256,11 +256,11 @@ plot_RatiosPG = function(df_ratios, d_range, main_title, main_col, legend_title)
     geom_area(aes_string(alpha = "ltype", fill = "col")) +
     xlab("ratio")  +
     ylab("density")  +
-    scale_fill_manual(values = rep(RColorBrewer::brewer.pal(6,"Accent"), times=40), guide_legend(legend_title)) + 
+    scale_fill_manual(values = rep(RColorBrewer::brewer.pal(6,"Accent"), times=40), guide = guide_legend(legend_title)) + 
     scale_colour_manual(values = rep(RColorBrewer::brewer.pal(6,"Accent"), times=40)) +
     suppressWarnings(scale_alpha_discrete(range = c(1, 0.2), 
                          labels=c("dotted"="unimodal", "solid"="multimodal"),
-                         guide_legend("shape")
+                         guide = guide_legend("shape")
     )) +
     scale_x_continuous(limits = d_range, trans = "identity", breaks = c(-br, 0, br), labels=c(paste0("1/",2^(br)), 1, 2^br)) +
     guides(color = "none") +


### PR DESCRIPTION
Hello there,

We have been preparing a new release of ggplot2 and during a reverse dependency check, it became apparent that the prospective ggplot2 3.5.0 would break PTXQC.

The issue is that we've harmonised most scales to have the `name` argument as the first argument. There were a few calls where a guide was passed as an unnamed argument and take up the place of the `name` argument. This PR fixes these calls to use a named argument for guides.

To test the code changes with the release candidate, you can install it with the code below:

```r
remotes::install_github("tidyverse/ggplot2", ref = remotes::github_pull("5592"))
```

The release of ggplot2 3.5.0 is scheduled for the 12th of February. The progress of the release can be tracked in https://github.com/tidyverse/ggplot2/issues/5588. We hope that this PR might help PTXQC get out a fix if necessary.